### PR TITLE
Fix open graph path and close README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ npm install
 
 # Run locally
 npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the site in your browser.
+

--- a/portfolio-site/app/layout.tsx
+++ b/portfolio-site/app/layout.tsx
@@ -40,14 +40,14 @@ export const metadata: Metadata = {
 		description: 'Passionate backend developer crafting scalable and efficient server architectures. Explore my projects and technical expertise.',
 		url: 'https://builtbybantan.com',
 		siteName: 'Fadil Bantan - Portfolio',
-		images: [
-			{
-				url: '/og-image.jpg',
-				width: 1200,
-				height: 630,
-				alt: 'Fadil Bantan - Software Engineer Portfolio',
-			},
-		],
+                images: [
+                        {
+                                url: '/laptop.jpg',
+                                width: 1200,
+                                height: 630,
+                                alt: 'Fadil Bantan - Software Engineer Portfolio',
+                        },
+                ],
 		locale: 'en_US',
 		type: 'website',
 	},
@@ -56,7 +56,7 @@ export const metadata: Metadata = {
 		title: 'Fadil Bantan - Software Engineer',
 		description: 'Passionate backend developer crafting scalable and efficient server architectures. Explore my projects and technical expertise.',
 		creator: '@fadelbantan',
-		images: ['/og-image.jpg'],
+                images: ['/laptop.jpg'],
 	},
 	robots: {
 		index: true,


### PR DESCRIPTION
## Summary
- fix OG image path to use `laptop.jpg`
- close the installation instructions block and add dev server link in README

## Testing
- `npx eslint app/layout.tsx` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'framer-motion' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f4aa1266c8328afde6336878d8e30